### PR TITLE
Add revealjs dependency using tag 3.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "reveal.js"]
+	path = reveal.js
+	url = https://github.com/hakimel/reveal.js.git


### PR DESCRIPTION
# Problem

When serving the slides revealjs dependencies are missing.

# Solution

Include revealjs submodule for dependency.